### PR TITLE
Fix ordering for taxonomy items

### DIFF
--- a/django/core/models.py
+++ b/django/core/models.py
@@ -90,8 +90,35 @@ class SoftDeleteModel(models.Model):
         self.save()
 
 
+class CustomNameOrderedQuerySet(ActiveQuerySet):
+
+    special_names = {
+        'NA',
+        'N/A',
+        'Unknown',
+        'Other',
+        'Bespoke',
+        'No'
+    }
+
+    def custom_ordered(self):
+        items = self.all()
+        items_front = []
+        items_back = []
+        for item in items:
+            if item.get("name", None) in self.special_names:  # pragma: no cover
+                items_front.append(item)
+            else:
+                items_back.append(item)
+
+        return items_front + items_back
+
+
 class ExtendedNameOrderedSoftDeletedModel(SoftDeleteModel, ExtendedModel):
     name = models.CharField(max_length=512)
+
+    all_objects = QuerySet.as_manager()
+    objects = CustomNameOrderedQuerySet.as_manager()
 
     class Meta:
         abstract = True

--- a/django/project/management/commands/create_portfolio_data_from_json.py
+++ b/django/project/management/commands/create_portfolio_data_from_json.py
@@ -24,9 +24,9 @@ class Command(BaseCommand, TestProjectData):
         pp.pprint('Creating background data if needed')
         self.org, _ = Organisation.objects.get_or_create(name=data_dict['organisation'])
         self.d1, _ = Donor.objects.get_or_create(name=data_dict['d1'],
-                                                 code=data_dict['d1'].lower().replace(' ', '_'))
+                                                 defaults={'code': data_dict['d1'].lower().replace(' ', '_')})
         self.d2, _ = Donor.objects.get_or_create(name=data_dict['d2'],
-                                                 code=data_dict['d2'].lower().replace(' ', '_'))
+                                                 defaults={'code': data_dict['d2'].lower().replace(' ', '_')})
         self.country, self.country_office = self.create_new_country_and_office(project_approval=False)
 
     @staticmethod

--- a/django/project/static-json/taxonomies.json
+++ b/django/project/static-json/taxonomies.json
@@ -1,6 +1,6 @@
 {
     "UNICEF Sector": [
-        "- NA",
+        "NA",
         "Adolescents",
         "C4D",
         "Child Protection",
@@ -90,13 +90,13 @@
         "WCAR 8 - Open Defecation and sustainable access to hygiene and sanitation"
     ],
     "If this is an innovation initiative, in which way is it innovative?": [
-        "- NA",
+        "NA",
         "Uses an entirely new tool or approach",
         "Brings a tool or approach to a new target group or population ",
         "Significantly improves our ability to deliver (e.g., much faster or cheaper than existing alternatives)"
     ],
     "UNICEF Innovation Categories": [
-        "- NA",
+        "NA",
         "Digital Innovation",
         "Frugal Innovation",
         "Innovative Financing",
@@ -104,8 +104,8 @@
         "Programme Innovation"
     ],
     "In Country programme document (CPD) and annual work plan?": [
-        "- NA",
-        "- No",
+        "NA",
+        "No",
         "2006",
         "2007",
         "2008",
@@ -814,7 +814,7 @@
         "Other Documents/Resources "
     ],
     "Phase of Initiative": [
-        "- NA",
+        "NA",
         "Opportunity and Ideation",
         "Preparation and Scoping",
         "Analysis and Design",
@@ -836,10 +836,10 @@
         "Technology"
     ],
     "Software Platform(s)": [
-        "- NA",
-        "- Unknown",
-        "- Other",
-        "- Bespoke",
+        "NA",
+        "Unknown",
+        "Other",
+        "Bespoke",
         ".Stat Suite",
         "ACCEDA",
         "Accessmod",
@@ -1105,9 +1105,9 @@
         "Zzapp"
     ],
     "Hardware Platform(s)/Physical Product(s)": [
-        "- NA",
-        "- Unknown",
-        "- Other",
+        "NA",
+        "Unknown",
+        "Other",
         "3D Printer",
         "Audio Devices",
         "Offline Server",
@@ -1130,9 +1130,9 @@
         "Wearables"
     ],
     "Non-Technology Platform(s)/Programme Innovation(s) and Non-Technology Platform(s)": [
-        "- NA",
-        "- Unknown",
-        "- Other",
+        "NA",
+        "Unknown",
+        "Other",
         "Adaptive Management",
         "Adolescent In Emergencies Kit",
         "Audit",
@@ -1170,9 +1170,9 @@
         "Youth Challenge"
     ],
     "Function(s) of Platform": [
-        "- NA",
-        "- Unknown",
-        "- Other",
+        "NA",
+        "Unknown",
+        "Other",
         "API",
         "Artificial Intelligence",
         "Asset Tracking",
@@ -1265,7 +1265,7 @@
         "Youth Engagement"
     ],
     "Information Security Classification as per UNICEF's Classi Tool": [
-        "Not Classified ",
+        "Not Classified",
         "Class I - Confidential",
         "Class II - Internal",
         "Class III - Internal",

--- a/django/project/test-data/test_data.json
+++ b/django/project/test-data/test_data.json
@@ -1,6 +1,6 @@
 {
   "general": {
-    "organisation": "Test org",
+    "organisation": "UNICEF",
     "d1": "UNICEF",
     "d2": "T Donor 2"
   },

--- a/django/project/views.py
+++ b/django/project/views.py
@@ -95,27 +95,30 @@ class ProjectPublicViewSet(ViewSet):
             ))
 
         return dict(
-            technology_platforms=TechnologyPlatform.objects.values('id', 'name'),
+            technology_platforms=TechnologyPlatform.objects.values('id', 'name').custom_ordered(),
             goal_areas=UNICEFGoal.objects.values('id', 'name', 'capability_level_question',
-                                                 'capability_category_question', 'capability_subcategory_question'),
-            result_areas=UNICEFResultArea.objects.values('id', 'name', 'goal_area_id'),
-            capability_levels=UNICEFCapabilityLevel.objects.values('id', 'name', 'goal_area_id'),
-            capability_categories=UNICEFCapabilityCategory.objects.values('id', 'name', 'goal_area_id'),
-            capability_subcategories=UNICEFCapabilitySubCategory.objects.values('id', 'name', 'goal_area_id'),
+                                                 'capability_category_question', 'capability_subcategory_question')
+            .custom_ordered(),
+            result_areas=UNICEFResultArea.objects.values('id', 'name', 'goal_area_id').custom_ordered(),
+            capability_levels=UNICEFCapabilityLevel.objects.values('id', 'name', 'goal_area_id').custom_ordered(),
+            capability_categories=UNICEFCapabilityCategory.objects.values('id', 'name', 'goal_area_id').
+            custom_ordered(),
+            capability_subcategories=UNICEFCapabilitySubCategory.objects.values('id', 'name', 'goal_area_id').
+            custom_ordered(),
             health_focus_areas=health_focus_areas,
             hsc_challenges=hsc_challenges,
             strategies=strategies,
             field_offices=FieldOffice.objects.values('id', 'name', 'country_office_id'),
             regional_offices=RegionalOffice.objects.values('id', 'name'),
             currencies=Currency.objects.values('id', 'name', 'code'),
-            sectors=UNICEFSector.objects.values('id', 'name'),
-            regional_priorities=RegionalPriority.objects.values('id', 'name'),
+            sectors=UNICEFSector.objects.values('id', 'name').custom_ordered(),
+            regional_priorities=RegionalPriority.objects.values('id', 'name').custom_ordered(),
             phases=Phase.objects.values('id', 'name'),
-            hardware=HardwarePlatform.objects.values('id', 'name'),
-            nontech=NontechPlatform.objects.values('id', 'name'),
-            functions=PlatformFunction.objects.values('id', 'name'),
-            cpd=CPD.objects.values('id', 'name'),
-            innovation_categories=InnovationCategory.objects.values('id', 'name')
+            hardware=HardwarePlatform.objects.values('id', 'name').custom_ordered(),
+            nontech=NontechPlatform.objects.values('id', 'name').custom_ordered(),
+            functions=PlatformFunction.objects.values('id', 'name').custom_ordered(),
+            cpd=CPD.objects.values('id', 'name').custom_ordered(),
+            innovation_categories=InnovationCategory.objects.values('id', 'name').custom_ordered()
         )
 
     @staticmethod
@@ -721,7 +724,7 @@ class PortfolioReviewAssignQuestionnaireViewSet(PortfolioAccessMixin, GenericVie
             if created:
                 from project.tasks import project_review_requested_on_create_notification
                 project_review_requested_on_create_notification.apply_async(args=[score.id,
-                                                                                  request.data.get('message', None)],)
+                                                                                  request.data.get('message', None)], )
         # return with scores
         data_serializer = ReviewScoreBriefSerializer(scores, many=True)
         return Response(data_serializer.data, status=status.HTTP_200_OK)


### PR DESCRIPTION
# Description

Introduced a new QuerySet for ExtendedNameOrderedSoftDeletedModel, on top of ActiveQuerySet, which adds a new function, custom_ordered, which puts the following values in front of the other values:
- NA
- N/A
- Unknown
- Other
- Bespoke
- No

This should be used when the special ordered output is needed.

Fixes # UT03-139

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Tested manually.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules