### PR TITLE
Remove PDF export option

### DIFF
--- a/frontend/components/dashboard/TableTopActions.vue
+++ b/frontend/components/dashboard/TableTopActions.vue
@@ -52,7 +52,7 @@
         <el-select v-model="exportType" size="small">
           <el-option label="CSV" value="CSV" />
           <el-option label="XLSX" value="XLSX" />
-          <el-option label="PDF" value="PDF" />
+          <!-- <el-option label="PDF" value="PDF" /> -->
         </el-select>
 
         <template v-if="showEmailButton">

--- a/frontend/components/portfolio/dashboard/TableTopActions.vue
+++ b/frontend/components/portfolio/dashboard/TableTopActions.vue
@@ -38,7 +38,7 @@
       <el-select v-model="exportType" :disabled="disabled" size="small">
         <el-option label="CSV" value="CSV" />
         <el-option label="XLSX" value="XLSX" />
-        <el-option label="PDF" value="PDF" />
+        <!-- <el-option label="PDF" value="PDF" /> -->
       </el-select>
     </div>
     <div class="right">


### PR DESCRIPTION
# Description

Remove, maybe temporally, the `PDF` export options on tables. 
