### PR TITLE
Add note limitation and no restriction for review form

### DIFF
--- a/frontend/components/project/sections/StageOverview.vue
+++ b/frontend/components/project/sections/StageOverview.vue
@@ -135,6 +135,8 @@
                     <custom-required-form-item class="stage__input">
                       <el-input
                         :value="stage.note"
+                        maxlength="256"
+                        show-word-limit
                         :placeholder="
                           $gettext('Add note (optional)') | translate
                         "
@@ -194,6 +196,8 @@
                 v-model="end_date_note"
                 v-validate="rules.end_date_note"
                 class="note"
+                maxlength="256"
+                show-word-limit
                 data-vv-name="end_date_note"
                 data-vv-as="End date note"
                 :placeholder="$gettext('Add note (optional)') | translate"

--- a/frontend/components/review/ReviewDialog.vue
+++ b/frontend/components/review/ReviewDialog.vue
@@ -84,7 +84,7 @@
           <p class="label">
             {{ `${idx + 1}/A: ` }}
             {{ reviewQuestions[question].name }}
-            <translate v-if="question === 'psa'">(optional)</translate>
+            <translate>(optional)</translate>
           </p>
           <p class="sub-label">
             {{ reviewQuestions[question].text }}
@@ -198,15 +198,15 @@ export default {
       reviewersList: 'system/getUserProfilesNoFilter',
     }),
     disabled() {
-      let disabled = false
-      this.questionType.forEach((type) => {
-        // we allow that psa is optional
-        if (type !== 'psa') {
-          if (this.score[type] === null || this.score[type] === '') {
-            disabled = true
-          }
-        }
-      })
+      const disabled = false
+      // this.questionType.forEach((type) => {
+      //   // we allow that psa is optional
+      //   if (type !== 'psa') {
+      //     if (this.score[type] === null || this.score[type] === '') {
+      //       disabled = true
+      //     }
+      //   }
+      // })
       return disabled
     },
     problemStatements() {


### PR DESCRIPTION
# Description

We need to set the limit for note input to 256 and allow blank submit for initiative review.

## Fixes

- UT03-370
- UT03-371 

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Client feedback. Manual test.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas