### PR TITLE
Select all, then deselect one row deselects all fixed

### DIFF
--- a/frontend/components/dashboard/MainTable.vue
+++ b/frontend/components/dashboard/MainTable.vue
@@ -735,9 +735,10 @@ export default {
       immediate: true,
       handler(value) {
         if (this.$refs.mainTable) {
-          this.$refs.mainTable.clearSelection()
           if (value) {
             this.$refs.mainTable.toggleAllSelection()
+          } else if (this.selectedRows.length === 0) {
+            this.$refs.mainTable.clearSelection()
           }
         }
       },

--- a/frontend/components/portfolio/dashboard/MainTable.vue
+++ b/frontend/components/portfolio/dashboard/MainTable.vue
@@ -794,9 +794,10 @@ export default {
       immediate: true,
       handler(value) {
         if (this.$refs.mainTable) {
-          this.$refs.mainTable.clearSelection()
           if (value) {
             this.$refs.mainTable.toggleAllSelection()
+          } else if (this.selectedRows.length === 0) {
+            this.$refs.mainTable.clearSelection()
           }
         }
       },


### PR DESCRIPTION
# Description

Select all, then deselect one row deselects all rows fixed.
There is an edge case that is another bug, but that needs some refactoring for the selection mechanism in the tables (inventory and portfolio).

**The case**
When someone selects all rows one by one, then the 'Select all' should change to 'Deselect all' and act like it. 
As the 'button' calls the table components **toggleAllSelection** method that has it's own mechanism (if all is selected, then deselect them, otherwise just select all rows).

Fixes **UT03-528**

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules