### PR TITLE
Moving project to portfolio edge case checked in ListExport component

### DIFF
--- a/frontend/components/dashboard/ListExport.vue
+++ b/frontend/components/dashboard/ListExport.vue
@@ -360,7 +360,8 @@ export default {
       if (
         !this.projects ||
         !this.projects[0] ||
-        typeof this.projects !== 'object'
+        typeof this.projects !== 'object' ||
+        (this.portfolioPage !== 'portfolio' && this.projects[0].review_states == null)
       ) {
         return null
       }


### PR DESCRIPTION
# Description

Moving projects to portfolio crashes the application.
This edge case is now checked in ListExport component.

Fixes UT03-550

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules