### PR TITLE
Fix export scores in innovation portfolio page

### DIFF
--- a/frontend/components/dashboard/ListExport.vue
+++ b/frontend/components/dashboard/ListExport.vue
@@ -360,10 +360,10 @@ export default {
     }),
     parsedScores() {
       if (
-        !this.projects ||
-        !this.projects[0] ||
-        typeof this.projects !== 'object' ||
-        (this.portfolioPage !== 'portfolio' && this.projects[0].review_states == null)
+        (!this.projects ||
+          !this.projects[0] ||
+          typeof this.projects !== 'object') &&
+        this.projects[0]?.review_states
       ) {
         return null
       }
@@ -380,7 +380,10 @@ export default {
           exportCols.push(i)
         }
       })
-      if (this.portfolioPage !== 'inventory') {
+      if (
+        this.portfolioPage !== 'inventory' &&
+        this.projects[0]?.review_states
+      ) {
         // official score header
         if (this.selectedCol.includes('62')) {
           row.push(...['', ...this.officialScoreFields])
@@ -418,7 +421,8 @@ export default {
         // generate reviews
         if (
           this.portfolioPage !== 'inventory' &&
-          this.selectedCol.includes('61')
+          this.selectedCol.includes('61') &&
+          this.projects[0]?.review_states
         ) {
           row.push(...this.parseReviews(p.review_states.review_scores))
         }

--- a/frontend/pages/_organisation/portfolio/innovation/_id.vue
+++ b/frontend/pages/_organisation/portfolio/innovation/_id.vue
@@ -250,15 +250,20 @@ export default {
       problemStatementMatrix: 'matrixes/getProblemStatementMatrix',
       name: 'portfolio/getName',
       description: 'portfolio/getDescription',
+      selectedColumns: 'dashboard/getSelectedColumns',
     }),
   },
   mounted() {
     this.getSearch()
+    this.setSelectedColumns(
+      this.selectedColumns.filter((s) => s !== '61' && s !== '62')
+    )
   },
   methods: {
     ...mapActions({
       loadProjectsMap: 'search/loadProjectsMap',
       getSearch: 'search/getSearch',
+      setSelectedColumns: 'dashboard/setSelectedColumns',
     }),
     navigate(id) {
       this.$store.dispatch('search/resetSearch')


### PR DESCRIPTION
# Description

Fixed exporting 'Score data' in Innovation Portfolio page. 
This page is public and the scores are for managers only.

Fixes UT03-561

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules