### PR TITLE
[UT03-721] Feature/Get countries by the new regions list in country

### DIFF
--- a/frontend/store/countries.js
+++ b/frontend/store/countries.js
@@ -82,7 +82,7 @@ export const getters = {
   },
   getCountriesByUnicefRegion: (state) => (unicef_region) => {
     const filtered = state.countries.filter((country) => {
-      return country.unicef_region === unicef_region
+      return country.regions.includes(unicef_region)
     })
     return [...filtered.map((c) => ({ ...c }))]
   },


### PR DESCRIPTION
# Description

There is a new field in countries `region` which actually a list of regions. So the country list in the filter section is now checking every country which's `region` array includes the selected region id.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Tested locally on a newly build docker image of the backend changes

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules