### PR TITLE
[UT03-709] Feat/Add edge case handle for no name-organization

### DIFF
--- a/frontend/components/project/TeamSelector.vue
+++ b/frontend/components/project/TeamSelector.vue
@@ -41,6 +41,9 @@
       <template v-if="person.organisation">
         <organisation-item :id="person.organisation" />
       </template>
+      <template v-else>
+        <br/>
+      </template>
       <span class="email"
         ><small>{{ person.email }}</small></span
       >


### PR DESCRIPTION
# Description

Added edge case for the option if there is no name/organization for proper show.
The underlying issue connected to the fact, that the el-popover element cannot guarantee that the popover element will be under the current dom element or it will be appended to the body.

Fixes issues when there is an empty organization or name

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Yes, it was tested locally before and after the changes

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings