### PR TITLE
UT03-754 bugfux/Fix news item gradient widths

### DIFF
--- a/frontend/components/landing/parts/NewsCard.vue
+++ b/frontend/components/landing/parts/NewsCard.vue
@@ -71,6 +71,7 @@ export default {
   }
 
   .content {
+    box-sizing: border-box;
     position: absolute;
     z-index: 5;
     display: flex;
@@ -78,6 +79,7 @@ export default {
     justify-content: flex-end;
     bottom: 0;
     height: 213px;
+    width: 100%;
     padding: 28px;
     background: linear-gradient(180deg, rgba(0, 0, 0, 0) 0%, #00000082 100%);
 


### PR DESCRIPTION
# Description

Fix news item's gradient to be full width even if the content is short.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules