### PR TITLE
[UT03-848] bugfux/Fix Safari table width calculation

### DIFF
--- a/frontend/components/common/TopBar.vue
+++ b/frontend/components/common/TopBar.vue
@@ -220,7 +220,7 @@ export default {
   }
 
   .RightPart {
-    padding: 14px 0;
+    padding: 9px 0;
 
     > .el-row > .el-col {
       width: auto;

--- a/frontend/components/common/UserDropdown.vue
+++ b/frontend/components/common/UserDropdown.vue
@@ -197,7 +197,7 @@ export default {
 }
 
 .UserDropdownPopper {
-  transform: translate(10px, -46px);
+  transform: translate(10px, -50px);
   border-radius: 5px;
   border: none;
 }

--- a/frontend/components/dashboard/MainTable.vue
+++ b/frontend/components/dashboard/MainTable.vue
@@ -805,6 +805,10 @@ export default {
 @import '~assets/style/variables.less';
 @import '~assets/style/mixins.less';
 
+.el-table table {
+  width: 0px;
+}
+
 .MainTable {
   margin: 0 40px 120px;
   max-height: calc(100vh - @topBarHeightSubpage - @actionBarHeight - @tableTopActionsHeight - @appFooterHeight - 93px);

--- a/frontend/components/landing/parts/Location.vue
+++ b/frontend/components/landing/parts/Location.vue
@@ -60,10 +60,14 @@ export default {
   span {
     position: relative;
     &.divider {
+      display: flex;
+      align-items: center;
       &::before {
         content: '';
         border: 1px solid @colorBrandGrayLight;
         margin-right: 8px;
+        height: 18px;
+        display: inline-block;
       }
     }
   }


### PR DESCRIPTION
# Description

HTML table width calculation in Element UI is not working properly in Safari browsers.
This is a quick fix for that.

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules