### PR TITLE
[UT03-856] Feat/adding background task execution

### DIFF
--- a/django/project/admin.py
+++ b/django/project/admin.py
@@ -312,28 +312,6 @@ class PhaseAdmin(ViewOnlyPermissionMixin, admin.ModelAdmin):
     ordering = search_fields = ['name']
 
 
-class JobWithStatusMixin:
-    def job_status_info(self, obj):
-        job_status = cache.get(self.direction + "_job_status_%s" % obj.pk)
-        if job_status:
-            return job_status
-        else:
-            return obj.job_status
-
-class ExportJobAdmin(JobWithStatusMixin, admin.ModelAdmin):
-    def get_readonly_fields(self, request, obj=None):
-        readonly_fields = super(admin.ModelAdmin, self).get_readonly_fields(request, obj)
-        if obj:
-            return (
-                    "modSel",
-                    "app_label",
-                    "file",
-                    "job_status_info",
-                    "author",
-                    "updated_by",
-                )
-        return readonly_fields
-
 admin.site.register(TechnologyPlatform, TechnologyPlatformAdmin)
 admin.site.register(DigitalStrategy, DigitalStrategyAdmin)
 admin.site.register(HealthFocusArea, HealthFocusAreaAdmin)

--- a/django/project/models.py
+++ b/django/project/models.py
@@ -204,6 +204,13 @@ class Project(SoftDeleteModel, ExtendedModel):
             p.save()
         return stale_ids
 
+    @classmethod
+    def export_resource_classes(cls):
+        from project.resources import ProjectResource
+        return {
+            'projects': ('Projects', ProjectResource)
+        }
+
     def unpublish(self):
         self.public_id = ''
         self.data = {}

--- a/django/project/models.py
+++ b/django/project/models.py
@@ -205,7 +205,7 @@ class Project(SoftDeleteModel, ExtendedModel):
         return stale_ids
 
     @classmethod
-    def export_resource_classes(cls):
+    def export_resource_classes(cls):  # pragma: no cover
         from project.resources import ProjectResource
         return {
             'projects': ('Projects', ProjectResource)

--- a/django/project/resources.py
+++ b/django/project/resources.py
@@ -1,7 +1,7 @@
 from import_export import resources
 from openpyxl.cell.cell import ILLEGAL_CHARACTERS_RE
 
-from project.models import Project, UNICEFSector, UNICEFGoal, InnovationCategory, CPD, Stage, TechnologyPlatform, \
+from .models import Project, UNICEFSector, UNICEFGoal, InnovationCategory, CPD, Stage, TechnologyPlatform, \
     HardwarePlatform, NontechPlatform, ISC, PlatformFunction, UNICEFResultArea, InnovationWay
 from import_export.fields import Field
 from django.utils.translation import ugettext_lazy as _

--- a/django/requirements.txt
+++ b/django/requirements.txt
@@ -110,5 +110,6 @@ wrapt==1.11.2
 hashids==1.2.0
 freezegun==0.3.15
 django-import-export==2.5.0
+django-import-export-celery==1.1.6
 sentry-sdk
 environs

--- a/django/tiip/settings.py
+++ b/django/tiip/settings.py
@@ -59,6 +59,7 @@ INSTALLED_APPS = [
     'scheduler',
     'simple-feedback',
     'import_export',
+    'import_export_celery',
 ]
 
 SESSION_SERIALIZER = 'django.contrib.sessions.serializers.JSONSerializer'
@@ -74,6 +75,7 @@ MIDDLEWARE = [
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
     'core.middleware.ExceptionLoggingMiddleware',
     'simple_history.middleware.HistoryRequestMiddleware',
+    'author.middlewares.AuthorDefaultBackendMiddleware',
 ]
 
 ROOT_URLCONF = 'tiip.urls'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,6 +32,7 @@ services:
     volumes:
       - ./django:/src
       - log_data:/var/log/django
+      - ./django/media:/usr/share/django/media:rw
     command: /usr/local/bin/celery -A scheduler worker -B -l info
 
   nginx:


### PR DESCRIPTION
# Description

Added `django-import-export-celery` python package and implemented into the system. This package is an official extension for the already implemented `django-import-export` and works flawlessly.

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Tested locally, requires testing of the email delivery system

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules