### PR TITLE
[UT03-862] Hotfix/hotfix for DHA related texts translations

### DIFF
--- a/frontend/components/DhaLogin.vue
+++ b/frontend/components/DhaLogin.vue
@@ -291,14 +291,18 @@ export default {
         return
       }
       try {
+        console.log("🚀 ~ file: DhaLogin.vue ~ line 296 ~ loginLocal ~ this.profile.country", this.profile.country)
         if (this.profile.country) {
           this.setSelectedCountry(this.profile.country)
         }
+        console.log("Basically this.$route.query:[",this.$route.query,"]")
         if (this.$route.query && this.$route.query.next) {
           const path = this.$route.query.next
           const query = { ...this.$route.query, next: undefined }
+          console.log("Yoko on 301: [",path,"]")
           this.$router.push({ path, query })
         } else {
+          console.log("Yoko on 304: [",this.$route.params,"]")
           this.$router.push(
             this.localePath({
               name: 'organisation-inventory-list',
@@ -308,6 +312,8 @@ export default {
           )
         }
       } catch (e) {
+        console.log("Oh no. It yoko. Basically this.$route.query:[",this.$route.query,"]")
+        console.log("YOKO E:[",e,"]")
         this.handleRoutingErrors(e)
       }
       this.$nuxt.$loading.finish('loginLoader')

--- a/frontend/components/admin/import/ImportFile.vue
+++ b/frontend/components/admin/import/ImportFile.vue
@@ -3,10 +3,7 @@
     <div class="Info">
       <p>
         <fa icon="info-circle" />
-        <translate>
-          The Import Interface allows you to import your Projects from an Excel
-          file into the Digital Health Atlas.
-        </translate>
+        <translate>The Import Interface allows you to import your Projects from an Excel file into the Digital Health Atlas.</translate>
       </p>
       <p>
         <translate> When importing your initiatives </translate>

--- a/frontend/components/project/sections/Categorization.vue
+++ b/frontend/components/project/sections/Categorization.vue
@@ -117,9 +117,7 @@
           class="DigitalHealthIntervention"
         >
           <template slot="label">
-            <translate key="strategies">
-              What are the Digital Health Intervention(s)?
-            </translate>
+            <translate key="strategies">What are the Digital Health Intervention(s)?</translate>
             <a
               class="TooltipLink"
               target="_blank"

--- a/frontend/components/project/sections/InteroperabilityAndStandards.vue
+++ b/frontend/components/project/sections/InteroperabilityAndStandards.vue
@@ -11,10 +11,7 @@
         :publish-rule="publishRules.interoperability_links"
       >
         <template slot="label">
-          <translate key="interoperability_links">
-            Does your project share information with one or more of these
-            digital Health Information System components?
-          </translate>
+          <translate key="interoperability_links">Does your project share information with one or more of these digital Health Information System components?</translate>
         </template>
 
         <interoperability-link-component
@@ -34,9 +31,7 @@
         :publish-rule="publishRules.interoperability_standards"
       >
         <template slot="label">
-          <translate key="interoperability-standards">
-            What data standards does your digital health project use?
-          </translate>
+          <translate key="interoperability-standards">What data standards does your digital health project use?</translate>
           <form-hint>
             <translate key="interoperability-standards-hint">
               If your data standards are not available here, please email

--- a/frontend/pages/_organisation/initiatives/create.vue
+++ b/frontend/pages/_organisation/initiatives/create.vue
@@ -3,10 +3,7 @@
     <div class="PageTitle">
       <h2><translate>Register your Digital Health Initiative</translate></h2>
       <p>
-        <translate
-          >Please complete the questions below to include your initiative information in the Digital Health Atlas. These
-          questions document your initiative's health focus area(s), software features and national scale.</translate
-        >
+        <translate>Please complete the questions below to include your initiative information in the Digital Health Atlas. These questions document your initiative's health focus area(s), software features and national scale.</translate>
       </p>
     </div>
     <project-form />


### PR DESCRIPTION
# Description

Quick fix for enabling translatability of strings that containe "Digital Health Atlas"


Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Locally

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code