### PR TITLE
[UT03-909][UT03-910][UT03-911][UT03-912] Feat/multiple workflow improvements on Export Celery plugin

### DIFF
--- a/django/project/admin.py
+++ b/django/project/admin.py
@@ -163,6 +163,7 @@ class HSCChallengeAdmin(ViewOnlyPermissionMixin, AllObjectsAdmin):
 
 
 class ProjectAdmin(ExportActionMixin, AllObjectsAdmin):
+    create_export_job_action.short_description = _("Generate export in the background")
     actions = (create_export_job_action,)
     list_display = ['__str__', 'modified', 'get_country', 'get_team', 'get_published', 'is_active', 'versions',
                     'featured', 'featured_rank']

--- a/django/tiip/settings.py
+++ b/django/tiip/settings.py
@@ -52,6 +52,7 @@ INSTALLED_APPS = [
     'simple_history',
     'sorl.thumbnail',
     'user',
+    'import_export_celery',
     'core',
     'project',
     'country',
@@ -60,7 +61,6 @@ INSTALLED_APPS = [
     'kpi',
     'simple-feedback',
     'import_export',
-    'import_export_celery',
 ]
 
 SESSION_SERIALIZER = 'django.contrib.sessions.serializers.JSONSerializer'


### PR DESCRIPTION
# Description

The following changes introduced in this commit:
- Renaming the app `verbose_name` in the admin
- Rename the dropdown action from `Export with celery` -> `Generate export in the background`
- Hiding the import section
- Hiding site of origin on the form

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Tested locally with `fab lint` and `fab cov`

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes